### PR TITLE
Place와 Room 엔티티 분리 및 CRUD API 구현

### DIFF
--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/controller/PlaceController.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/controller/PlaceController.java
@@ -1,0 +1,42 @@
+package com.gsh118.spacelink.controller;
+
+import com.gsh118.spacelink.dto.request.PlaceCreateRequest;
+import com.gsh118.spacelink.dto.response.PlaceResponse;
+import com.gsh118.spacelink.service.PlaceService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/places")
+@RequiredArgsConstructor
+public class PlaceController {
+
+    private final PlaceService placeService;
+
+    @GetMapping
+    public ResponseEntity<List<PlaceResponse>> getAllPlaces() {
+        return ResponseEntity.ok(placeService.getAllPlaces());
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<PlaceResponse> getPlaceById(@PathVariable Long id) {
+        return ResponseEntity.ok(placeService.getPlaceById(id));
+    }
+
+    @PostMapping
+    public ResponseEntity<PlaceResponse> createPlace(@Valid @RequestBody PlaceCreateRequest request) {
+        PlaceResponse response = placeService.createPlace(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePlace(@PathVariable Long id) {
+        placeService.deletePlace(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/controller/RoomController.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/controller/RoomController.java
@@ -20,9 +20,9 @@ public class RoomController {
 
     @GetMapping
     public ResponseEntity<List<RoomResponse>> getAllRooms(
-            @RequestParam(required = false) String location) {
-        if (location != null && !location.isEmpty()) {
-            return ResponseEntity.ok(roomService.getRoomsByLocation(location));
+            @RequestParam(required = false) Long placeId) {
+        if (placeId != null) {
+            return ResponseEntity.ok(roomService.getRoomsByPlaceId(placeId));
         }
         return ResponseEntity.ok(roomService.getAllRooms());
     }

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/request/PlaceCreateRequest.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/request/PlaceCreateRequest.java
@@ -1,0 +1,21 @@
+package com.gsh118.spacelink.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class PlaceCreateRequest {
+
+    @NotBlank(message = "Name is required")
+    private String name;
+
+    private String description;
+
+    private Double latitude;
+
+    private Double longitude;
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/request/RoomCreateRequest.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/request/RoomCreateRequest.java
@@ -14,11 +14,11 @@ import java.math.BigDecimal;
 @AllArgsConstructor
 public class RoomCreateRequest {
 
+    @NotNull(message = "Place ID is required")
+    private Long placeId;
+
     @NotBlank(message = "Name is required")
     private String name;
-
-    @NotBlank(message = "Location is required")
-    private String location;
 
     @NotNull(message = "Capacity is required")
     @Positive(message = "Capacity must be positive")

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/response/PlaceResponse.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/response/PlaceResponse.java
@@ -1,0 +1,37 @@
+package com.gsh118.spacelink.dto.response;
+
+import com.gsh118.spacelink.entity.Location;
+import com.gsh118.spacelink.entity.Place;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PlaceResponse {
+    private Long id;
+    private String name;
+    private String description;
+    private Double latitude;
+    private Double longitude;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static PlaceResponse from(Place place) {
+        Location location = place.getLocation();
+        return PlaceResponse.builder()
+            .id(place.getId())
+            .name(place.getName())
+            .description(place.getDescription())
+            .latitude(location != null ? location.getLatitude() : null)
+            .longitude(location != null ? location.getLongitude() : null)
+            .createdAt(place.getCreatedAt())
+            .updatedAt(place.getUpdatedAt())
+            .build();
+    }
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/response/RoomResponse.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/dto/response/RoomResponse.java
@@ -15,8 +15,9 @@ import java.time.LocalDateTime;
 @Builder
 public class RoomResponse {
     private Long id;
+    private Long placeId;
+    private String placeName;
     private String name;
-    private String location;
     private Integer capacity;
     private BigDecimal pricePerHour;
     private String description;
@@ -27,8 +28,9 @@ public class RoomResponse {
     public static RoomResponse from(Room room) {
         return RoomResponse.builder()
             .id(room.getId())
+            .placeId(room.getPlace().getId())
+            .placeName(room.getPlace().getName())
             .name(room.getName())
-            .location(room.getLocation())
             .capacity(room.getCapacity())
             .pricePerHour(room.getPricePerHour())
             .description(room.getDescription())

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/Location.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/Location.java
@@ -1,0 +1,19 @@
+package com.gsh118.spacelink.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Location {
+    private Double latitude;
+    private Double longitude;
+
+    public Location(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/Place.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/Place.java
@@ -1,0 +1,48 @@
+package com.gsh118.spacelink.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "place")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Place {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Embedded
+    private Location location;
+
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
+    private List<Room> rooms = new ArrayList<>();
+
+    @CreationTimestamp
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Place(String name, String description, Location location) {
+        this.name = name;
+        this.description = description;
+        this.location = location;
+    }
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/PlaceManager.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/PlaceManager.java
@@ -1,0 +1,26 @@
+package com.gsh118.spacelink.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PlaceManager {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    private Long placeId;
+    private Long managerId;
+
+    public PlaceManager(Long placeId, Long managerId) {
+        this.placeId = placeId;
+        this.managerId = managerId;
+    }
+
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/Room.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/entity/Room.java
@@ -20,11 +20,12 @@ public class Room {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "place_id", nullable = false)
+    private Place place;
+
     @Column(nullable = false, length = 100)
     private String name;
-
-    @Column(nullable = false)
-    private String location;
 
     @Column(nullable = false)
     private Integer capacity;
@@ -50,9 +51,9 @@ public class Room {
     private LocalDateTime updatedAt;
 
     @Builder
-    public Room(String name, String location, Integer capacity, BigDecimal pricePerHour, String description, String amenities) {
+    public Room(Place place, String name, Integer capacity, BigDecimal pricePerHour, String description, String amenities) {
+        this.place = place;
         this.name = name;
-        this.location = location;
         this.capacity = capacity;
         this.pricePerHour = pricePerHour;
         this.description = description;

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/repository/PlaceRepository.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/repository/PlaceRepository.java
@@ -1,0 +1,9 @@
+package com.gsh118.spacelink.repository;
+
+import com.gsh118.spacelink.entity.Place;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/repository/RoomRepository.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/repository/RoomRepository.java
@@ -8,6 +8,6 @@ import java.util.List;
 
 @Repository
 public interface RoomRepository extends JpaRepository<Room, Long> {
-    List<Room> findByLocationContaining(String location);
+    List<Room> findByPlaceId(Long placeId);
     List<Room> findByCapacityGreaterThanEqual(Integer capacity);
 }

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/service/PlaceService.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/service/PlaceService.java
@@ -1,0 +1,58 @@
+package com.gsh118.spacelink.service;
+
+import com.gsh118.spacelink.dto.request.PlaceCreateRequest;
+import com.gsh118.spacelink.dto.response.PlaceResponse;
+import com.gsh118.spacelink.entity.Location;
+import com.gsh118.spacelink.entity.Place;
+import com.gsh118.spacelink.repository.PlaceRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PlaceService {
+
+    private final PlaceRepository placeRepository;
+
+    public List<PlaceResponse> getAllPlaces() {
+        return placeRepository.findAll().stream()
+            .map(PlaceResponse::from)
+            .collect(Collectors.toList());
+    }
+
+    public PlaceResponse getPlaceById(Long id) {
+        Place place = placeRepository.findById(id)
+            .orElseThrow(() -> new RuntimeException("Place not found with id: " + id));
+        return PlaceResponse.from(place);
+    }
+
+    @Transactional
+    public PlaceResponse createPlace(PlaceCreateRequest request) {
+        Location location = null;
+        if (request.getLatitude() != null && request.getLongitude() != null) {
+            location = new Location(request.getLatitude(), request.getLongitude());
+        }
+
+        Place place = Place.builder()
+            .name(request.getName())
+            .description(request.getDescription())
+            .location(location)
+            .build();
+
+        Place savedPlace = placeRepository.save(place);
+        return PlaceResponse.from(savedPlace);
+    }
+
+    @Transactional
+    public void deletePlace(Long id) {
+        if (!placeRepository.existsById(id)) {
+            throw new RuntimeException("Place not found with id: " + id);
+        }
+        placeRepository.deleteById(id);
+    }
+}

--- a/backend/spacelink/src/main/java/com/gsh118/spacelink/service/RoomService.java
+++ b/backend/spacelink/src/main/java/com/gsh118/spacelink/service/RoomService.java
@@ -2,7 +2,9 @@ package com.gsh118.spacelink.service;
 
 import com.gsh118.spacelink.dto.request.RoomCreateRequest;
 import com.gsh118.spacelink.dto.response.RoomResponse;
+import com.gsh118.spacelink.entity.Place;
 import com.gsh118.spacelink.entity.Room;
+import com.gsh118.spacelink.repository.PlaceRepository;
 import com.gsh118.spacelink.repository.RoomRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +19,7 @@ import java.util.stream.Collectors;
 public class RoomService {
 
     private final RoomRepository roomRepository;
+    private final PlaceRepository placeRepository;
 
     public List<RoomResponse> getAllRooms() {
         return roomRepository.findAll().stream()
@@ -30,17 +33,20 @@ public class RoomService {
         return RoomResponse.from(room);
     }
 
-    public List<RoomResponse> getRoomsByLocation(String location) {
-        return roomRepository.findByLocationContaining(location).stream()
+    public List<RoomResponse> getRoomsByPlaceId(Long placeId) {
+        return roomRepository.findByPlaceId(placeId).stream()
             .map(RoomResponse::from)
             .collect(Collectors.toList());
     }
 
     @Transactional
     public RoomResponse createRoom(RoomCreateRequest request) {
+        Place place = placeRepository.findById(request.getPlaceId())
+            .orElseThrow(() -> new RuntimeException("Place not found with id: " + request.getPlaceId()));
+
         Room room = Room.builder()
+            .place(place)
             .name(request.getName())
-            .location(request.getLocation())
             .capacity(request.getCapacity())
             .pricePerHour(request.getPricePerHour())
             .description(request.getDescription())

--- a/backend/spacelink/src/main/resources/sql/data.sql
+++ b/backend/spacelink/src/main/resources/sql/data.sql
@@ -6,16 +6,24 @@ INSERT INTO users (email, password, name, role) VALUES
 ('user1@test.com', '$2a$10$dummyHashedPassword2', '김철수', 'ROLE_USER'),
 ('user2@test.com', '$2a$10$dummyHashedPassword3', '이영희', 'ROLE_USER');
 
+-- Sample Places
+INSERT INTO place (name, description, latitude, longitude) VALUES
+('강남 테헤란 지점', '서울 강남구에 위치한 메인 지점입니다.', 37.5012767241426, 127.039600248343),
+('서초 센터', '서울 서초구에 위치한 비즈니스 센터입니다.', 37.4830366358305, 127.032469459556),
+('종로 본점', '서울 종로구에 위치한 본점입니다.', 37.5720164, 126.9769519),
+('마포 지점', '서울 마포구에 위치한 소규모 지점입니다.', 37.5443882, 126.9513254),
+('판교 테크센터', '경기 성남시 분당구 판교에 위치한 IT 특화 센터입니다.', 37.3951683, 127.1107129);
+
 -- Sample Rooms
-INSERT INTO room (name, location, capacity, price_per_hour, description, amenities) VALUES
-('스터디룸 A', '서울 강남구 테헤란로 123', 4, 15000.00, '조용하고 깨끗한 4인용 스터디룸입니다.', 'WIFI,WHITEBOARD,MONITOR'),
-('스터디룸 B', '서울 강남구 테헤란로 123', 6, 20000.00, '넓은 6인용 스터디룸으로 팀 프로젝트에 적합합니다.', 'WIFI,WHITEBOARD,PROJECTOR,MONITOR'),
-('회의실 C', '서울 서초구 서초대로 456', 8, 30000.00, '전문적인 비즈니스 미팅을 위한 회의실입니다.', 'WIFI,PROJECTOR,MONITOR,WHITEBOARD,COFFEE'),
-('소회의실 D', '서울 서초구 서초대로 456', 4, 18000.00, '소규모 미팅에 최적화된 공간입니다.', 'WIFI,MONITOR,WHITEBOARD'),
-('대형 스터디룸 E', '서울 종로구 종로 789', 10, 35000.00, '대규모 스터디나 세미나에 적합한 공간입니다.', 'WIFI,PROJECTOR,WHITEBOARD,SOUND_SYSTEM'),
-('프라이빗 룸 F', '서울 마포구 마포대로 321', 2, 12000.00, '1:1 과외나 개인 스터디에 적합합니다.', 'WIFI,MONITOR'),
-('스터디 라운지 G', '경기 성남시 분당구 판교역로 111', 6, 22000.00, '편안한 분위기의 스터디 공간입니다.', 'WIFI,WHITEBOARD,COFFEE,SNACKS'),
-('테크 회의실 H', '경기 성남시 분당구 판교역로 111', 8, 28000.00, 'IT 업계 미팅에 최적화된 회의실입니다.', 'WIFI,DUAL_MONITOR,WHITEBOARD,VIDEO_CONFERENCE');
+INSERT INTO room (place_id, name, capacity, price_per_hour, description, amenities) VALUES
+(1, '스터디룸 A', 4, 15000.00, '조용하고 깨끗한 4인용 스터디룸입니다.', 'WIFI,WHITEBOARD,MONITOR'),
+(1, '스터디룸 B', 6, 20000.00, '넓은 6인용 스터디룸으로 팀 프로젝트에 적합합니다.', 'WIFI,WHITEBOARD,PROJECTOR,MONITOR'),
+(2, '회의실 C', 8, 30000.00, '전문적인 비즈니스 미팅을 위한 회의실입니다.', 'WIFI,PROJECTOR,MONITOR,WHITEBOARD,COFFEE'),
+(2, '소회의실 D', 4, 18000.00, '소규모 미팅에 최적화된 공간입니다.', 'WIFI,MONITOR,WHITEBOARD'),
+(3, '대형 스터디룸 E', 10, 35000.00, '대규모 스터디나 세미나에 적합한 공간입니다.', 'WIFI,PROJECTOR,WHITEBOARD,SOUND_SYSTEM'),
+(4, '프라이빗 룸 F', 2, 12000.00, '1:1 과외나 개인 스터디에 적합합니다.', 'WIFI,MONITOR'),
+(5, '스터디 라운지 G', 6, 22000.00, '편안한 분위기의 스터디 공간입니다.', 'WIFI,WHITEBOARD,COFFEE,SNACKS'),
+(5, '테크 회의실 H', 8, 28000.00, 'IT 업계 미팅에 최적화된 회의실입니다.', 'WIFI,DUAL_MONITOR,WHITEBOARD,VIDEO_CONFERENCE');
 
 -- Sample Bookings
 INSERT INTO booking (user_id, room_id, start_time, end_time, status, total_price) VALUES

--- a/backend/spacelink/src/main/resources/sql/schema.sql
+++ b/backend/spacelink/src/main/resources/sql/schema.sql
@@ -3,6 +3,7 @@
 -- Drop tables if exist (for clean initialization)
 DROP TABLE IF EXISTS booking;
 DROP TABLE IF EXISTS room;
+DROP TABLE IF EXISTS place;
 DROP TABLE IF EXISTS users;
 
 -- User Table
@@ -16,17 +17,29 @@ CREATE TABLE users (
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
 
+-- Place Table
+CREATE TABLE place (
+    id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    latitude DOUBLE,
+    longitude DOUBLE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
 -- Room Table
 CREATE TABLE room (
     id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    place_id BIGINT NOT NULL,
     name VARCHAR(100) NOT NULL,
-    location VARCHAR(255) NOT NULL,
     capacity INT NOT NULL,
     price_per_hour DECIMAL(10, 2) NOT NULL,
     description TEXT,
     amenities VARCHAR(500),
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (place_id) REFERENCES place(id) ON DELETE CASCADE
 );
 
 -- Booking Table
@@ -46,6 +59,7 @@ CREATE TABLE booking (
 
 -- Indexes for performance
 CREATE INDEX idx_user_email ON users(email);
+CREATE INDEX idx_room_place_id ON room(place_id);
 CREATE INDEX idx_booking_user_id ON booking(user_id);
 CREATE INDEX idx_booking_room_id ON booking(room_id);
 CREATE INDEX idx_booking_time ON booking(start_time, end_time);


### PR DESCRIPTION
## 변경 사항
회의실 예약 시스템을 Place(건물/장소) → Room(회의실) 계층 구조로 변경

### 엔티티 구조
- Place 엔티티: 건물/장소 정보 (name, description, location)
- Location: @Embeddable로 위도/경도 관리
- Room 엔티티: Place에 @ManyToOne으로 종속

### 구현 내용
**Place CRUD API 추가**
- PlaceRepository, PlaceService, PlaceController
- PlaceCreateRequest, PlaceResponse
- GET /api/v1/places, POST /api/v1/places, DELETE /api/v1/places/{id}

**Room API 수정**
- placeId 기반 필터링 (GET /api/v1/rooms?placeId=1)
- Room 생성 시 Place 존재 확인
- RoomResponse에 placeId, placeName 추가

**데이터베이스**
- place 테이블 추가 (위도/경도 포함)
- room 테이블 수정 (location → place_id)
- 샘플 데이터: 5개 장소, 8개 회의실

Closes #7